### PR TITLE
README: -f is now the default behavior, no need to specify it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To initialize your local repository, use command:
 Then sync up:
 
 ```bash
-    repo sync  -f --force-sync --no-clone-bundle -jX
+    repo sync --force-sync --no-clone-bundle -jX
 ```
 Where X is the thread your CPU can handle.
 


### PR DESCRIPTION
"-f/--force-broken is now the default behavior, and the options are deprecated"

The warning by the repo tool.